### PR TITLE
Reference DOI, change it to be like the others.

### DIFF
--- a/elife-00666.xml
+++ b/elife-00666.xml
@@ -2719,7 +2719,7 @@ The tagging of the collaborator name again within this section is required for P
             <volume>36</volume>
             <fpage>120</fpage>
             <lpage>131</lpage>
-            <pub-id pub-id-type="doi">https://doi.org/10.1016/j.immuni.2011.11.018</pub-id>
+            <pub-id pub-id-type="doi">10.1016/j.immuni.2011.11.018</pub-id>
             <pub-id pub-id-type="pmid">22284419</pub-id> 
         </element-citation>
     </ref>


### PR DESCRIPTION
This change is ok @Melissa37 ? It is to match all the others so I assume it might be ok to fix this. It is causing validation issue that I didn't see last week when testing conversion to EIF, so I think it is a recent change.