### PR TITLE
Change the iso-8601-date to match the date tags for the preprint.

### DIFF
--- a/elife-00666.xml
+++ b/elife-00666.xml
@@ -442,7 +442,7 @@ content must work as a discrete item on each author's roll over and on the displ
                     <event-desc>This article was ogininally published as a <ext-link ext-link-type="uri" 
                         xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</ext-link>
                     </event-desc>
-                    <date iso-8601-date="2016-03-01">
+                    <date iso-8601-date="2017-03-24">
                         <day>24</day>
                         <month>03</month>
                         <year>2017</year>


### PR DESCRIPTION
Remove some confusion having an iso date attribute that is different than the date tags.