### PR TITLE
Add to author response content more sample data.

### DIFF
--- a/elife-00666.xml
+++ b/elife-00666.xml
@@ -4628,6 +4628,47 @@ UPDATE: DOI prefix removed from XML but must be added for display-->
             </mml:math>
             </inline-formula>
             </p>
+            <p>May also contain a formula as a block
+            <disp-formula>
+                <mml:math>
+                    <mml:mrow>
+                        <mml:mi>ϕ</mml:mi>
+                        <mml:mo>=</mml:mo>
+                        <mml:msup>
+                            <mml:mi>e</mml:mi>
+                            <mml:mrow>
+                                <mml:mo>−</mml:mo>
+                                <mml:mfrac>
+                                    <mml:mrow>
+                                        <mml:mi>z</mml:mi>
+                                        <mml:mi>F</mml:mi>
+                                        <mml:mi>V</mml:mi>
+                                    </mml:mrow>
+                                    <mml:mrow>
+                                        <mml:mi>n</mml:mi>
+                                        <mml:mi>R</mml:mi>
+                                        <mml:mi>T</mml:mi>
+                                    </mml:mrow>
+                                </mml:mfrac>
+                            </mml:mrow>
+                        </mml:msup>
+                    </mml:mrow>
+                </mml:math>
+            </disp-formula>
+            </p>
+            <list list-type="order">
+                <list-item>
+                    <p>'Contamination'</p>
+                    <list list-type="roman-lower">
+                        <list-item>
+                            <p>Cell line <sup>superscript</sup><sub>subscript</sub> &amp; p&lt;0.001</p>
+                        </list-item>
+                        <list-item>
+                            <p><italic>C. elegans</italic></p>
+                        </list-item>
+                    </list>
+                </list-item>
+            </list>
         </body>
     </sub-article>
 </article>

--- a/elife-00666.xml
+++ b/elife-00666.xml
@@ -518,7 +518,7 @@ NOTE: research advance MUST contain <related-article related-article-type="artic
                     An abstract can contain any formatting, such as <italic>italics</italic>,
                         <bold>bold</bold>, <sup>superscript</sup>, <sub>subscript</sub> or <sc>small caps</sc>. MathML is
                     also allowed: 
-                    <inline-formula><mml:math>
+                    <inline-formula><mml:math id="inf1">
                         <mml:mrow>
                             <mml:munder>
                                 <mml:mo/>
@@ -1554,7 +1554,7 @@ not add all rids to the xref as it does not work. Only add the first one -->
                         Formally, this corresponds to a (Gaussian) prior belief (with mean
                         <inline-formula>
                             <!-- no id required for inline formulae -->
-                            <mml:math>
+                            <mml:math id="inf2">
                                 <mml:mstyle displaystyle="true" scriptlevel="0">
                                     <mml:mrow>
                                         <mml:msub>
@@ -1569,7 +1569,7 @@ not add all rids to the xref as it does not work. Only add the first one -->
                         </inline-formula>
                         and variance
                         <inline-formula>
-                            <mml:math>
+                            <mml:math id="inf3">
                                 <mml:mstyle displaystyle="true" scriptlevel="0">
                                     <mml:mrow>
                                         <mml:msubsup>
@@ -1587,7 +1587,7 @@ not add all rids to the xref as it does not work. Only add the first one -->
                         </inline-formula>
                         over the mean of a (Gaussian) distribution of reward options R (with variance
                         <inline-formula>
-                            <mml:math>
+                            <mml:math id="inf4">
                                 <mml:mstyle displaystyle="true" scriptlevel="0">
                                     <mml:mrow>
                                         <mml:msubsup>
@@ -4607,7 +4607,7 @@ UPDATE: DOI prefix removed from XML but must be added for display-->
                 1989</xref>), however, if it is a new reference only cited in the decision letter or author response it is not added to the main reference link and is just listed as free
                 text, for example, Butcher et al, 2006. If the author provides the reference it can be added as free text to the end of the letter, however, this is not a requirement
                 .</p>
-            <p>Adding some MathML to the sub-article.<inline-formula><mml:math>
+            <p>Adding some MathML to the sub-article.<inline-formula><mml:math id="inf5">
                 <mml:mrow>
                     <mml:munder>
                         <mml:mo/>

--- a/elife-00666.xml
+++ b/elife-00666.xml
@@ -4629,8 +4629,8 @@ UPDATE: DOI prefix removed from XML but must be added for display-->
             </inline-formula>
             </p>
             <p>May also contain a formula as a block
-            <disp-formula>
-                <mml:math>
+            <disp-formula id="equ4">
+                <mml:math id="m4">
                     <mml:mrow>
                         <mml:mi>ϕ</mml:mi>
                         <mml:mo>=</mml:mo>


### PR DESCRIPTION
Regarding issue https://github.com/elifesciences/XML-mapping/issues/88, I wanted to add some more types of content that may appear in a decision letter or author response.

I was happy to find many of the content types were already represented in the kitchen sink XML.

Here I'm suggesting to add some additional content to the author response that I didn't see was represented in any `<sub-article>`:

- `<disp-formula>`
- unicode character: ϕ
- `<list>` with a nested `<list>`, with `@list-type` of `order` and `roman-lower` (ones I've observed in samples so far)
- apostrophe character '
- `<sub>`
- `<sup>`
- escaped ampersand `&amp;`
- unmatched angle bracket `&lt;`
- `<italic>`

How these are represented is up to revising and suggestions. This may inform how a decision letter parser library XML output sample may look, which may be loosely based on this kitchen sink XML.